### PR TITLE
fix: month view selection

### DIFF
--- a/src/components/TableMatrixView.tsx
+++ b/src/components/TableMatrixView.tsx
@@ -22,7 +22,7 @@ const TableMatrixView: React.FunctionComponent<Props> = ({ className, matrix, ce
       )}
       <tbody>
         {matrix.map((row, i) => (
-          <tr key={i}>{row.map((v, j) => cell(v, i + j))}</tr>
+          <tr key={i}>{row.map((v, j) => cell(v, i * matrix[i].length + j))}</tr>
         ))}
       </tbody>
     </table>

--- a/test/__snapshots__/CalendarContainer.test.tsx.snap
+++ b/test/__snapshots__/CalendarContainer.test.tsx.snap
@@ -301,7 +301,7 @@ exports[`<CalendarContainer/> prop: locale should locale prop correctly 1`] = `
                 >
                   <Cell
                     className="calendar__day calendar__day--0"
-                    key="1"
+                    key="7"
                     onClick={[Function]}
                     onMouseOver={[Function]}
                     subText=""
@@ -319,7 +319,7 @@ exports[`<CalendarContainer/> prop: locale should locale prop correctly 1`] = `
                   </Cell>
                   <Cell
                     className="calendar__day calendar__day--1"
-                    key="2"
+                    key="8"
                     onClick={[Function]}
                     onMouseOver={[Function]}
                     subText=""
@@ -337,7 +337,7 @@ exports[`<CalendarContainer/> prop: locale should locale prop correctly 1`] = `
                   </Cell>
                   <Cell
                     className="calendar__day calendar__day--2"
-                    key="3"
+                    key="9"
                     onClick={[Function]}
                     onMouseOver={[Function]}
                     subText=""
@@ -355,7 +355,7 @@ exports[`<CalendarContainer/> prop: locale should locale prop correctly 1`] = `
                   </Cell>
                   <Cell
                     className="calendar__day calendar__day--3"
-                    key="4"
+                    key="10"
                     onClick={[Function]}
                     onMouseOver={[Function]}
                     subText=""
@@ -373,7 +373,7 @@ exports[`<CalendarContainer/> prop: locale should locale prop correctly 1`] = `
                   </Cell>
                   <Cell
                     className="calendar__day calendar__day--4"
-                    key="5"
+                    key="11"
                     onClick={[Function]}
                     onMouseOver={[Function]}
                     subText=""
@@ -391,7 +391,7 @@ exports[`<CalendarContainer/> prop: locale should locale prop correctly 1`] = `
                   </Cell>
                   <Cell
                     className="calendar__day calendar__day--5"
-                    key="6"
+                    key="12"
                     onClick={[Function]}
                     onMouseOver={[Function]}
                     subText=""
@@ -409,7 +409,7 @@ exports[`<CalendarContainer/> prop: locale should locale prop correctly 1`] = `
                   </Cell>
                   <Cell
                     className="calendar__day calendar__day--6"
-                    key="7"
+                    key="13"
                     onClick={[Function]}
                     onMouseOver={[Function]}
                     subText=""
@@ -431,7 +431,7 @@ exports[`<CalendarContainer/> prop: locale should locale prop correctly 1`] = `
                 >
                   <Cell
                     className="calendar__day calendar__day--0"
-                    key="2"
+                    key="14"
                     onClick={[Function]}
                     onMouseOver={[Function]}
                     subText=""
@@ -449,7 +449,7 @@ exports[`<CalendarContainer/> prop: locale should locale prop correctly 1`] = `
                   </Cell>
                   <Cell
                     className="calendar__day calendar__day--1"
-                    key="3"
+                    key="15"
                     onClick={[Function]}
                     onMouseOver={[Function]}
                     subText=""
@@ -467,7 +467,7 @@ exports[`<CalendarContainer/> prop: locale should locale prop correctly 1`] = `
                   </Cell>
                   <Cell
                     className="calendar__day calendar__day--2"
-                    key="4"
+                    key="16"
                     onClick={[Function]}
                     onMouseOver={[Function]}
                     subText=""
@@ -485,7 +485,7 @@ exports[`<CalendarContainer/> prop: locale should locale prop correctly 1`] = `
                   </Cell>
                   <Cell
                     className="calendar__day calendar__day--3"
-                    key="5"
+                    key="17"
                     onClick={[Function]}
                     onMouseOver={[Function]}
                     subText=""
@@ -503,7 +503,7 @@ exports[`<CalendarContainer/> prop: locale should locale prop correctly 1`] = `
                   </Cell>
                   <Cell
                     className="calendar__day calendar__day--4"
-                    key="6"
+                    key="18"
                     onClick={[Function]}
                     onMouseOver={[Function]}
                     subText=""
@@ -521,7 +521,7 @@ exports[`<CalendarContainer/> prop: locale should locale prop correctly 1`] = `
                   </Cell>
                   <Cell
                     className="calendar__day calendar__day--5"
-                    key="7"
+                    key="19"
                     onClick={[Function]}
                     onMouseOver={[Function]}
                     subText=""
@@ -539,7 +539,7 @@ exports[`<CalendarContainer/> prop: locale should locale prop correctly 1`] = `
                   </Cell>
                   <Cell
                     className="calendar__day calendar__day--6"
-                    key="8"
+                    key="20"
                     onClick={[Function]}
                     onMouseOver={[Function]}
                     subText=""
@@ -561,7 +561,7 @@ exports[`<CalendarContainer/> prop: locale should locale prop correctly 1`] = `
                 >
                   <Cell
                     className="calendar__day calendar__day--0"
-                    key="3"
+                    key="21"
                     onClick={[Function]}
                     onMouseOver={[Function]}
                     subText=""
@@ -579,7 +579,7 @@ exports[`<CalendarContainer/> prop: locale should locale prop correctly 1`] = `
                   </Cell>
                   <Cell
                     className="calendar__day calendar__day--1"
-                    key="4"
+                    key="22"
                     onClick={[Function]}
                     onMouseOver={[Function]}
                     subText=""
@@ -597,7 +597,7 @@ exports[`<CalendarContainer/> prop: locale should locale prop correctly 1`] = `
                   </Cell>
                   <Cell
                     className="calendar__day calendar__day--2"
-                    key="5"
+                    key="23"
                     onClick={[Function]}
                     onMouseOver={[Function]}
                     subText=""
@@ -615,7 +615,7 @@ exports[`<CalendarContainer/> prop: locale should locale prop correctly 1`] = `
                   </Cell>
                   <Cell
                     className="calendar__day calendar__day--3"
-                    key="6"
+                    key="24"
                     onClick={[Function]}
                     onMouseOver={[Function]}
                     subText=""
@@ -633,7 +633,7 @@ exports[`<CalendarContainer/> prop: locale should locale prop correctly 1`] = `
                   </Cell>
                   <Cell
                     className="calendar__day calendar__day--4"
-                    key="7"
+                    key="25"
                     onClick={[Function]}
                     onMouseOver={[Function]}
                     subText=""
@@ -651,7 +651,7 @@ exports[`<CalendarContainer/> prop: locale should locale prop correctly 1`] = `
                   </Cell>
                   <Cell
                     className="calendar__day calendar__day--5"
-                    key="8"
+                    key="26"
                     onClick={[Function]}
                     onMouseOver={[Function]}
                     subText=""
@@ -669,7 +669,7 @@ exports[`<CalendarContainer/> prop: locale should locale prop correctly 1`] = `
                   </Cell>
                   <Cell
                     className="calendar__day calendar__day--6"
-                    key="9"
+                    key="27"
                     onClick={[Function]}
                     onMouseOver={[Function]}
                     subText=""
@@ -691,7 +691,7 @@ exports[`<CalendarContainer/> prop: locale should locale prop correctly 1`] = `
                 >
                   <Cell
                     className="calendar__day calendar__day--0"
-                    key="4"
+                    key="28"
                     onClick={[Function]}
                     onMouseOver={[Function]}
                     subText=""
@@ -709,7 +709,7 @@ exports[`<CalendarContainer/> prop: locale should locale prop correctly 1`] = `
                   </Cell>
                   <Cell
                     className="calendar__day calendar__day--1"
-                    key="5"
+                    key="29"
                     onClick={[Function]}
                     onMouseOver={[Function]}
                     subText=""
@@ -727,7 +727,7 @@ exports[`<CalendarContainer/> prop: locale should locale prop correctly 1`] = `
                   </Cell>
                   <Cell
                     className="calendar__day calendar__day--2"
-                    key="6"
+                    key="30"
                     onClick={[Function]}
                     onMouseOver={[Function]}
                     subText=""
@@ -745,7 +745,7 @@ exports[`<CalendarContainer/> prop: locale should locale prop correctly 1`] = `
                   </Cell>
                   <Cell
                     className="calendar__day calendar__day--3"
-                    key="7"
+                    key="31"
                     onClick={[Function]}
                     onMouseOver={[Function]}
                     subText=""
@@ -763,7 +763,7 @@ exports[`<CalendarContainer/> prop: locale should locale prop correctly 1`] = `
                   </Cell>
                   <Cell
                     className="calendar__day calendar__day--4"
-                    key="8"
+                    key="32"
                     onClick={[Function]}
                     onMouseOver={[Function]}
                     subText=""
@@ -781,7 +781,7 @@ exports[`<CalendarContainer/> prop: locale should locale prop correctly 1`] = `
                   </Cell>
                   <Cell
                     className="calendar__day calendar__day--5"
-                    key="9"
+                    key="33"
                     onClick={[Function]}
                     onMouseOver={[Function]}
                     subText=""
@@ -799,7 +799,7 @@ exports[`<CalendarContainer/> prop: locale should locale prop correctly 1`] = `
                   </Cell>
                   <Cell
                     className="calendar__day calendar__day--6"
-                    key="10"
+                    key="34"
                     onClick={[Function]}
                     onMouseOver={[Function]}
                     subText=""
@@ -821,7 +821,7 @@ exports[`<CalendarContainer/> prop: locale should locale prop correctly 1`] = `
                 >
                   <Cell
                     className="calendar__day calendar__day--0"
-                    key="5"
+                    key="35"
                     onClick={[Function]}
                     onMouseOver={[Function]}
                     subText=""
@@ -839,7 +839,7 @@ exports[`<CalendarContainer/> prop: locale should locale prop correctly 1`] = `
                   </Cell>
                   <Cell
                     className="calendar__day calendar__day--1"
-                    key="6"
+                    key="36"
                     onClick={[Function]}
                     onMouseOver={[Function]}
                     subText=""
@@ -857,7 +857,7 @@ exports[`<CalendarContainer/> prop: locale should locale prop correctly 1`] = `
                   </Cell>
                   <Cell
                     className=""
-                    key="7"
+                    key="37"
                     onClick={[Function]}
                     onMouseOver={[Function]}
                     subText=""
@@ -875,7 +875,7 @@ exports[`<CalendarContainer/> prop: locale should locale prop correctly 1`] = `
                   </Cell>
                   <Cell
                     className=""
-                    key="8"
+                    key="38"
                     onClick={[Function]}
                     onMouseOver={[Function]}
                     subText=""
@@ -893,7 +893,7 @@ exports[`<CalendarContainer/> prop: locale should locale prop correctly 1`] = `
                   </Cell>
                   <Cell
                     className=""
-                    key="9"
+                    key="39"
                     onClick={[Function]}
                     onMouseOver={[Function]}
                     subText=""
@@ -911,7 +911,7 @@ exports[`<CalendarContainer/> prop: locale should locale prop correctly 1`] = `
                   </Cell>
                   <Cell
                     className=""
-                    key="10"
+                    key="40"
                     onClick={[Function]}
                     onMouseOver={[Function]}
                     subText=""
@@ -929,7 +929,7 @@ exports[`<CalendarContainer/> prop: locale should locale prop correctly 1`] = `
                   </Cell>
                   <Cell
                     className=""
-                    key="11"
+                    key="41"
                     onClick={[Function]}
                     onMouseOver={[Function]}
                     subText=""

--- a/test/__snapshots__/DayView.test.tsx.snap
+++ b/test/__snapshots__/DayView.test.tsx.snap
@@ -263,7 +263,7 @@ exports[`<DayView/> prop: selected should render correctly 1`] = `
         >
           <Cell
             className="calendar__day calendar__day--0"
-            key="1"
+            key="7"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -281,7 +281,7 @@ exports[`<DayView/> prop: selected should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--1"
-            key="2"
+            key="8"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -299,7 +299,7 @@ exports[`<DayView/> prop: selected should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--2"
-            key="3"
+            key="9"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -317,7 +317,7 @@ exports[`<DayView/> prop: selected should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--3"
-            key="4"
+            key="10"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -335,7 +335,7 @@ exports[`<DayView/> prop: selected should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--4"
-            key="5"
+            key="11"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -353,7 +353,7 @@ exports[`<DayView/> prop: selected should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--5"
-            key="6"
+            key="12"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -371,7 +371,7 @@ exports[`<DayView/> prop: selected should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--6"
-            key="7"
+            key="13"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -393,7 +393,7 @@ exports[`<DayView/> prop: selected should render correctly 1`] = `
         >
           <Cell
             className="calendar__day calendar__day--0"
-            key="2"
+            key="14"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -411,7 +411,7 @@ exports[`<DayView/> prop: selected should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--1"
-            key="3"
+            key="15"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -429,7 +429,7 @@ exports[`<DayView/> prop: selected should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--2"
-            key="4"
+            key="16"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -447,7 +447,7 @@ exports[`<DayView/> prop: selected should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--3 calendar__day--selected"
-            key="5"
+            key="17"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -465,7 +465,7 @@ exports[`<DayView/> prop: selected should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--4"
-            key="6"
+            key="18"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -483,7 +483,7 @@ exports[`<DayView/> prop: selected should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--5"
-            key="7"
+            key="19"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -501,7 +501,7 @@ exports[`<DayView/> prop: selected should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--6 calendar__day--selected"
-            key="8"
+            key="20"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -523,7 +523,7 @@ exports[`<DayView/> prop: selected should render correctly 1`] = `
         >
           <Cell
             className="calendar__day calendar__day--0"
-            key="3"
+            key="21"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -541,7 +541,7 @@ exports[`<DayView/> prop: selected should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--1"
-            key="4"
+            key="22"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -559,7 +559,7 @@ exports[`<DayView/> prop: selected should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--2"
-            key="5"
+            key="23"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -577,7 +577,7 @@ exports[`<DayView/> prop: selected should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--3"
-            key="6"
+            key="24"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -595,7 +595,7 @@ exports[`<DayView/> prop: selected should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--4"
-            key="7"
+            key="25"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -613,7 +613,7 @@ exports[`<DayView/> prop: selected should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--5"
-            key="8"
+            key="26"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -631,7 +631,7 @@ exports[`<DayView/> prop: selected should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--6 calendar__day--selected"
-            key="9"
+            key="27"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -653,7 +653,7 @@ exports[`<DayView/> prop: selected should render correctly 1`] = `
         >
           <Cell
             className="calendar__day calendar__day--0"
-            key="4"
+            key="28"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -671,7 +671,7 @@ exports[`<DayView/> prop: selected should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--1"
-            key="5"
+            key="29"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -689,7 +689,7 @@ exports[`<DayView/> prop: selected should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--2"
-            key="6"
+            key="30"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -707,7 +707,7 @@ exports[`<DayView/> prop: selected should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--3"
-            key="7"
+            key="31"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -725,7 +725,7 @@ exports[`<DayView/> prop: selected should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--4"
-            key="8"
+            key="32"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -743,7 +743,7 @@ exports[`<DayView/> prop: selected should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--5"
-            key="9"
+            key="33"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -761,7 +761,7 @@ exports[`<DayView/> prop: selected should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--6"
-            key="10"
+            key="34"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -783,7 +783,7 @@ exports[`<DayView/> prop: selected should render correctly 1`] = `
         >
           <Cell
             className="calendar__day calendar__day--0"
-            key="5"
+            key="35"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -801,7 +801,7 @@ exports[`<DayView/> prop: selected should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--1"
-            key="6"
+            key="36"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -819,7 +819,7 @@ exports[`<DayView/> prop: selected should render correctly 1`] = `
           </Cell>
           <Cell
             className=""
-            key="7"
+            key="37"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -837,7 +837,7 @@ exports[`<DayView/> prop: selected should render correctly 1`] = `
           </Cell>
           <Cell
             className=""
-            key="8"
+            key="38"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -855,7 +855,7 @@ exports[`<DayView/> prop: selected should render correctly 1`] = `
           </Cell>
           <Cell
             className=""
-            key="9"
+            key="39"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -873,7 +873,7 @@ exports[`<DayView/> prop: selected should render correctly 1`] = `
           </Cell>
           <Cell
             className=""
-            key="10"
+            key="40"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -891,7 +891,7 @@ exports[`<DayView/> prop: selected should render correctly 1`] = `
           </Cell>
           <Cell
             className=""
-            key="11"
+            key="41"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -1171,7 +1171,7 @@ exports[`<DayView/> prop: startDay, endDay should render correctly 1`] = `
         >
           <Cell
             className="calendar__day calendar__day--0"
-            key="1"
+            key="7"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -1189,7 +1189,7 @@ exports[`<DayView/> prop: startDay, endDay should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--1"
-            key="2"
+            key="8"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -1207,7 +1207,7 @@ exports[`<DayView/> prop: startDay, endDay should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--2"
-            key="3"
+            key="9"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -1225,7 +1225,7 @@ exports[`<DayView/> prop: startDay, endDay should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--3 calendar__day--start"
-            key="4"
+            key="10"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -1243,7 +1243,7 @@ exports[`<DayView/> prop: startDay, endDay should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--4 calendar__day--range"
-            key="5"
+            key="11"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -1261,7 +1261,7 @@ exports[`<DayView/> prop: startDay, endDay should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--5 calendar__day--range"
-            key="6"
+            key="12"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -1279,7 +1279,7 @@ exports[`<DayView/> prop: startDay, endDay should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--6 calendar__day--range"
-            key="7"
+            key="13"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -1301,7 +1301,7 @@ exports[`<DayView/> prop: startDay, endDay should render correctly 1`] = `
         >
           <Cell
             className="calendar__day calendar__day--0 calendar__day--range"
-            key="2"
+            key="14"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -1319,7 +1319,7 @@ exports[`<DayView/> prop: startDay, endDay should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--1 calendar__day--range"
-            key="3"
+            key="15"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -1337,7 +1337,7 @@ exports[`<DayView/> prop: startDay, endDay should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--2 calendar__day--end"
-            key="4"
+            key="16"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -1355,7 +1355,7 @@ exports[`<DayView/> prop: startDay, endDay should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--3"
-            key="5"
+            key="17"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -1373,7 +1373,7 @@ exports[`<DayView/> prop: startDay, endDay should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--4"
-            key="6"
+            key="18"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -1391,7 +1391,7 @@ exports[`<DayView/> prop: startDay, endDay should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--5"
-            key="7"
+            key="19"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -1409,7 +1409,7 @@ exports[`<DayView/> prop: startDay, endDay should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--6"
-            key="8"
+            key="20"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -1431,7 +1431,7 @@ exports[`<DayView/> prop: startDay, endDay should render correctly 1`] = `
         >
           <Cell
             className="calendar__day calendar__day--0"
-            key="3"
+            key="21"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -1449,7 +1449,7 @@ exports[`<DayView/> prop: startDay, endDay should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--1"
-            key="4"
+            key="22"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -1467,7 +1467,7 @@ exports[`<DayView/> prop: startDay, endDay should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--2"
-            key="5"
+            key="23"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -1485,7 +1485,7 @@ exports[`<DayView/> prop: startDay, endDay should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--3"
-            key="6"
+            key="24"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -1503,7 +1503,7 @@ exports[`<DayView/> prop: startDay, endDay should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--4"
-            key="7"
+            key="25"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -1521,7 +1521,7 @@ exports[`<DayView/> prop: startDay, endDay should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--5"
-            key="8"
+            key="26"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -1539,7 +1539,7 @@ exports[`<DayView/> prop: startDay, endDay should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--6"
-            key="9"
+            key="27"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -1561,7 +1561,7 @@ exports[`<DayView/> prop: startDay, endDay should render correctly 1`] = `
         >
           <Cell
             className="calendar__day calendar__day--0"
-            key="4"
+            key="28"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -1579,7 +1579,7 @@ exports[`<DayView/> prop: startDay, endDay should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--1"
-            key="5"
+            key="29"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -1597,7 +1597,7 @@ exports[`<DayView/> prop: startDay, endDay should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--2"
-            key="6"
+            key="30"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -1615,7 +1615,7 @@ exports[`<DayView/> prop: startDay, endDay should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--3"
-            key="7"
+            key="31"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -1633,7 +1633,7 @@ exports[`<DayView/> prop: startDay, endDay should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--4"
-            key="8"
+            key="32"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -1651,7 +1651,7 @@ exports[`<DayView/> prop: startDay, endDay should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--5"
-            key="9"
+            key="33"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -1669,7 +1669,7 @@ exports[`<DayView/> prop: startDay, endDay should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--6"
-            key="10"
+            key="34"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -1691,7 +1691,7 @@ exports[`<DayView/> prop: startDay, endDay should render correctly 1`] = `
         >
           <Cell
             className="calendar__day calendar__day--0"
-            key="5"
+            key="35"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -1709,7 +1709,7 @@ exports[`<DayView/> prop: startDay, endDay should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--1"
-            key="6"
+            key="36"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -1727,7 +1727,7 @@ exports[`<DayView/> prop: startDay, endDay should render correctly 1`] = `
           </Cell>
           <Cell
             className=""
-            key="7"
+            key="37"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -1745,7 +1745,7 @@ exports[`<DayView/> prop: startDay, endDay should render correctly 1`] = `
           </Cell>
           <Cell
             className=""
-            key="8"
+            key="38"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -1763,7 +1763,7 @@ exports[`<DayView/> prop: startDay, endDay should render correctly 1`] = `
           </Cell>
           <Cell
             className=""
-            key="9"
+            key="39"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -1781,7 +1781,7 @@ exports[`<DayView/> prop: startDay, endDay should render correctly 1`] = `
           </Cell>
           <Cell
             className=""
-            key="10"
+            key="40"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -1799,7 +1799,7 @@ exports[`<DayView/> prop: startDay, endDay should render correctly 1`] = `
           </Cell>
           <Cell
             className=""
-            key="11"
+            key="41"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -2078,7 +2078,7 @@ exports[`<DayView/> prop:customClass, customText should render correctly 1`] = `
         >
           <Cell
             className="calendar__day calendar__day--0 custom-day day-test1 day-test2"
-            key="1"
+            key="7"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText="신정"
@@ -2101,7 +2101,7 @@ exports[`<DayView/> prop:customClass, customText should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--1"
-            key="2"
+            key="8"
             onClick={[Function]}
             onMouseOver={[Function]}
             text="3"
@@ -2118,7 +2118,7 @@ exports[`<DayView/> prop:customClass, customText should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--2"
-            key="3"
+            key="9"
             onClick={[Function]}
             onMouseOver={[Function]}
             text="4"
@@ -2135,7 +2135,7 @@ exports[`<DayView/> prop:customClass, customText should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--3"
-            key="4"
+            key="10"
             onClick={[Function]}
             onMouseOver={[Function]}
             text="5"
@@ -2152,7 +2152,7 @@ exports[`<DayView/> prop:customClass, customText should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--4"
-            key="5"
+            key="11"
             onClick={[Function]}
             onMouseOver={[Function]}
             text="6"
@@ -2169,7 +2169,7 @@ exports[`<DayView/> prop:customClass, customText should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--5"
-            key="6"
+            key="12"
             onClick={[Function]}
             onMouseOver={[Function]}
             text="7"
@@ -2186,7 +2186,7 @@ exports[`<DayView/> prop:customClass, customText should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--6"
-            key="7"
+            key="13"
             onClick={[Function]}
             onMouseOver={[Function]}
             text="8"
@@ -2207,7 +2207,7 @@ exports[`<DayView/> prop:customClass, customText should render correctly 1`] = `
         >
           <Cell
             className="calendar__day calendar__day--0"
-            key="2"
+            key="14"
             onClick={[Function]}
             onMouseOver={[Function]}
             text="9"
@@ -2224,7 +2224,7 @@ exports[`<DayView/> prop:customClass, customText should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--1"
-            key="3"
+            key="15"
             onClick={[Function]}
             onMouseOver={[Function]}
             text="10"
@@ -2241,7 +2241,7 @@ exports[`<DayView/> prop:customClass, customText should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--2 custom-day"
-            key="4"
+            key="16"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText="공휴일"
@@ -2264,7 +2264,7 @@ exports[`<DayView/> prop:customClass, customText should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--3"
-            key="5"
+            key="17"
             onClick={[Function]}
             onMouseOver={[Function]}
             text="12"
@@ -2281,7 +2281,7 @@ exports[`<DayView/> prop:customClass, customText should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--4"
-            key="6"
+            key="18"
             onClick={[Function]}
             onMouseOver={[Function]}
             text="13"
@@ -2298,7 +2298,7 @@ exports[`<DayView/> prop:customClass, customText should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--5"
-            key="7"
+            key="19"
             onClick={[Function]}
             onMouseOver={[Function]}
             text="14"
@@ -2315,7 +2315,7 @@ exports[`<DayView/> prop:customClass, customText should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--6"
-            key="8"
+            key="20"
             onClick={[Function]}
             onMouseOver={[Function]}
             text="15"
@@ -2336,7 +2336,7 @@ exports[`<DayView/> prop:customClass, customText should render correctly 1`] = `
         >
           <Cell
             className="calendar__day calendar__day--0"
-            key="3"
+            key="21"
             onClick={[Function]}
             onMouseOver={[Function]}
             text="16"
@@ -2353,7 +2353,7 @@ exports[`<DayView/> prop:customClass, customText should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--1"
-            key="4"
+            key="22"
             onClick={[Function]}
             onMouseOver={[Function]}
             text="17"
@@ -2370,7 +2370,7 @@ exports[`<DayView/> prop:customClass, customText should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--2"
-            key="5"
+            key="23"
             onClick={[Function]}
             onMouseOver={[Function]}
             text="18"
@@ -2387,7 +2387,7 @@ exports[`<DayView/> prop:customClass, customText should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--3"
-            key="6"
+            key="24"
             onClick={[Function]}
             onMouseOver={[Function]}
             text="19"
@@ -2404,7 +2404,7 @@ exports[`<DayView/> prop:customClass, customText should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--4"
-            key="7"
+            key="25"
             onClick={[Function]}
             onMouseOver={[Function]}
             text="20"
@@ -2421,7 +2421,7 @@ exports[`<DayView/> prop:customClass, customText should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--5"
-            key="8"
+            key="26"
             onClick={[Function]}
             onMouseOver={[Function]}
             text="21"
@@ -2438,7 +2438,7 @@ exports[`<DayView/> prop:customClass, customText should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--6"
-            key="9"
+            key="27"
             onClick={[Function]}
             onMouseOver={[Function]}
             text="22"
@@ -2459,7 +2459,7 @@ exports[`<DayView/> prop:customClass, customText should render correctly 1`] = `
         >
           <Cell
             className="calendar__day calendar__day--0"
-            key="4"
+            key="28"
             onClick={[Function]}
             onMouseOver={[Function]}
             text="23"
@@ -2476,7 +2476,7 @@ exports[`<DayView/> prop:customClass, customText should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--1"
-            key="5"
+            key="29"
             onClick={[Function]}
             onMouseOver={[Function]}
             text="24"
@@ -2493,7 +2493,7 @@ exports[`<DayView/> prop:customClass, customText should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--2"
-            key="6"
+            key="30"
             onClick={[Function]}
             onMouseOver={[Function]}
             text="25"
@@ -2510,7 +2510,7 @@ exports[`<DayView/> prop:customClass, customText should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--3"
-            key="7"
+            key="31"
             onClick={[Function]}
             onMouseOver={[Function]}
             text="26"
@@ -2527,7 +2527,7 @@ exports[`<DayView/> prop:customClass, customText should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--4"
-            key="8"
+            key="32"
             onClick={[Function]}
             onMouseOver={[Function]}
             text="27"
@@ -2544,7 +2544,7 @@ exports[`<DayView/> prop:customClass, customText should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--5"
-            key="9"
+            key="33"
             onClick={[Function]}
             onMouseOver={[Function]}
             text="28"
@@ -2561,7 +2561,7 @@ exports[`<DayView/> prop:customClass, customText should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--6"
-            key="10"
+            key="34"
             onClick={[Function]}
             onMouseOver={[Function]}
             text="29"
@@ -2582,7 +2582,7 @@ exports[`<DayView/> prop:customClass, customText should render correctly 1`] = `
         >
           <Cell
             className="calendar__day calendar__day--0"
-            key="5"
+            key="35"
             onClick={[Function]}
             onMouseOver={[Function]}
             text="30"
@@ -2599,7 +2599,7 @@ exports[`<DayView/> prop:customClass, customText should render correctly 1`] = `
           </Cell>
           <Cell
             className="calendar__day calendar__day--1"
-            key="6"
+            key="36"
             onClick={[Function]}
             onMouseOver={[Function]}
             text="31"
@@ -2616,7 +2616,7 @@ exports[`<DayView/> prop:customClass, customText should render correctly 1`] = `
           </Cell>
           <Cell
             className=""
-            key="7"
+            key="37"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -2634,7 +2634,7 @@ exports[`<DayView/> prop:customClass, customText should render correctly 1`] = `
           </Cell>
           <Cell
             className=""
-            key="8"
+            key="38"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -2652,7 +2652,7 @@ exports[`<DayView/> prop:customClass, customText should render correctly 1`] = `
           </Cell>
           <Cell
             className=""
-            key="9"
+            key="39"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -2670,7 +2670,7 @@ exports[`<DayView/> prop:customClass, customText should render correctly 1`] = `
           </Cell>
           <Cell
             className=""
-            key="10"
+            key="40"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""
@@ -2688,7 +2688,7 @@ exports[`<DayView/> prop:customClass, customText should render correctly 1`] = `
           </Cell>
           <Cell
             className=""
-            key="11"
+            key="41"
             onClick={[Function]}
             onMouseOver={[Function]}
             subText=""

--- a/test/__snapshots__/TableMatrixView.test.tsx.snap
+++ b/test/__snapshots__/TableMatrixView.test.tsx.snap
@@ -47,17 +47,17 @@ exports[`<TableMatrixView/> props matrix correctly 1`] = `
       key="1"
     >
       <td
-        key="1"
-      >
-        value
-      </td>
-      <td
-        key="2"
-      >
-        value
-      </td>
-      <td
         key="3"
+      >
+        value
+      </td>
+      <td
+        key="4"
+      >
+        value
+      </td>
+      <td
+        key="5"
       >
         value
       </td>
@@ -66,17 +66,17 @@ exports[`<TableMatrixView/> props matrix correctly 1`] = `
       key="2"
     >
       <td
-        key="2"
+        key="6"
       >
         value
       </td>
       <td
-        key="3"
+        key="7"
       >
         value
       </td>
       <td
-        key="4"
+        key="8"
       >
         value
       </td>
@@ -132,17 +132,17 @@ exports[`<TableMatrixView/> render with no props 1`] = `
       key="1"
     >
       <td
-        key="1"
-      >
-        value
-      </td>
-      <td
-        key="2"
-      >
-        value
-      </td>
-      <td
         key="3"
+      >
+        value
+      </td>
+      <td
+        key="4"
+      >
+        value
+      </td>
+      <td
+        key="5"
       >
         value
       </td>
@@ -151,17 +151,17 @@ exports[`<TableMatrixView/> render with no props 1`] = `
       key="2"
     >
       <td
-        key="2"
+        key="6"
       >
         value
       </td>
       <td
-        key="3"
+        key="7"
       >
         value
       </td>
       <td
-        key="4"
+        key="8"
       >
         value
       </td>


### PR DESCRIPTION
At the moment month selector is broken. The cause of issue is wrong computation of selected item's index based on current matrix row/column. This pull request fixes mentioned computation.